### PR TITLE
Allow authentication from custom hostnames

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       KEYCLOAK_URL: http://keycloak:8080
       KEYCLOAK_ADMIN_PASSWORD: admin
       KEYCLOAK_CLIENT_SECRET: dev-secret-change-in-production
+      PUBLIC_API_URL: ${PUBLIC_API_URL:-http://localhost:3000}
     volumes:
       - ./infra/keycloak-init.sh:/scripts/keycloak-init.sh:ro
     command: >
@@ -100,9 +101,9 @@ services:
       - PUBLIC_API_PORT=3000
       - ADMIN_API_PORT=3001
       - META_API_PORT=3002
-      - PUBLIC_API_URL=http://localhost:3000
-      - ADMIN_API_URL=http://localhost:3001
-      - META_API_URL=http://localhost:3002
+      - PUBLIC_API_URL=${PUBLIC_API_URL:-http://localhost:3000}
+      - ADMIN_API_URL=${ADMIN_API_URL:-http://localhost:3001}
+      - META_API_URL=${META_API_URL:-http://localhost:3002}
       - DB_HOST=postgres
       - DB_PORT=5432
       - DB_NAME=antithesis
@@ -113,7 +114,7 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - KEYCLOAK_URL=http://keycloak:8080
-      - KEYCLOAK_PUBLIC_URL=http://localhost:8080
+      - KEYCLOAK_PUBLIC_URL=${KEYCLOAK_PUBLIC_URL:-http://localhost:8080}
       - KEYCLOAK_REALM=antithesis
       - KEYCLOAK_CLIENT_ID=antithesis-app
       - KEYCLOAK_CLIENT_SECRET=dev-secret-change-in-production

--- a/infra/keycloak-init.sh
+++ b/infra/keycloak-init.sh
@@ -13,6 +13,7 @@ KEYCLOAK_URL=${KEYCLOAK_URL:-http://localhost:8080}
 KEYCLOAK_ADMIN=${KEYCLOAK_ADMIN:-admin}
 KEYCLOAK_REALM=antithesis
 KEYCLOAK_CLIENT_ID=antithesis-app
+PUBLIC_API_URL=${PUBLIC_API_URL:-http://localhost:3000}
 
 echo "🔧 Initializing Keycloak for E2E tests..."
 echo "   URL: $KEYCLOAK_URL"

--- a/infra/keycloak-init.sh
+++ b/infra/keycloak-init.sh
@@ -59,19 +59,29 @@ if [ "$REALM_EXISTS" = "404" ]; then
   echo "✅ Realm created"
 else
   echo "ℹ️  Realm already exists, updating SSL requirement..."
+
+  # GET current realm configuration
+  CURRENT_REALM=$(curl -sS -X GET \
+    "$KEYCLOAK_URL/admin/realms/$KEYCLOAK_REALM" \
+    -H "Authorization: Bearer $ADMIN_TOKEN")
+
+  # Check if GET was successful
+  if [ -z "$CURRENT_REALM" ] || [ "$CURRENT_REALM" = "null" ]; then
+    echo "❌ Failed to fetch current realm configuration"
+    exit 1
+  fi
+
+  # Merge: Update only sslRequired field, preserve everything else
+  UPDATED_REALM=$(echo "$CURRENT_REALM" | jq '.sslRequired = "none"')
+
+  # PUT the complete merged configuration back
   curl -sS -X PUT \
     "$KEYCLOAK_URL/admin/realms/$KEYCLOAK_REALM" \
     -H "Authorization: Bearer $ADMIN_TOKEN" \
     -H "Content-Type: application/json" \
-    -d "{
-      \"realm\": \"$KEYCLOAK_REALM\",
-      \"enabled\": true,
-      \"registrationAllowed\": false,
-      \"loginWithEmailAllowed\": true,
-      \"duplicateEmailsAllowed\": false,
-      \"sslRequired\": \"none\"
-    }"
-  echo "✅ Realm updated"
+    -d "$UPDATED_REALM"
+
+  echo "✅ Realm updated (SSL requirement set to 'none', all other settings preserved)"
 fi
 
 # Create OIDC client
@@ -113,32 +123,32 @@ if [ "$CLIENT_EXISTS" = "0" ]; then
   echo "✅ OIDC client created"
 else
   echo "ℹ️  OIDC client already exists, updating redirect URIs..."
+
+  # GET current client configuration
+  CURRENT_CLIENT=$(curl -sS -X GET \
+    "$KEYCLOAK_URL/admin/realms/$KEYCLOAK_REALM/clients/$CLIENT_UUID" \
+    -H "Authorization: Bearer $ADMIN_TOKEN")
+
+  # Check if GET was successful
+  if [ -z "$CURRENT_CLIENT" ] || [ "$CURRENT_CLIENT" = "null" ]; then
+    echo "❌ Failed to fetch current client configuration"
+    exit 1
+  fi
+
+  # Merge: Update only redirectUris and webOrigins, preserve everything else
+  UPDATED_CLIENT=$(echo "$CURRENT_CLIENT" | jq \
+    --argjson redirectUris '["http://127.0.0.1:13000/auth/callback","http://localhost:13000/auth/callback","'"${PUBLIC_API_URL}"'/auth/callback"]' \
+    --argjson webOrigins '["http://127.0.0.1:13000","http://localhost:13000","'"${PUBLIC_API_URL}"'"]' \
+    '.redirectUris = $redirectUris | .webOrigins = $webOrigins')
+
+  # PUT the complete merged configuration back
   curl -sS -X PUT \
     "$KEYCLOAK_URL/admin/realms/$KEYCLOAK_REALM/clients/$CLIENT_UUID" \
     -H "Authorization: Bearer $ADMIN_TOKEN" \
     -H "Content-Type: application/json" \
-    -d "{
-      \"id\": \"$CLIENT_UUID\",
-      \"clientId\": \"$KEYCLOAK_CLIENT_ID\",
-      \"enabled\": true,
-      \"protocol\": \"openid-connect\",
-      \"publicClient\": false,
-      \"standardFlowEnabled\": true,
-      \"directAccessGrantsEnabled\": false,
-      \"serviceAccountsEnabled\": false,
-      \"redirectUris\": [
-        \"http://127.0.0.1:13000/auth/callback\",
-        \"http://localhost:13000/auth/callback\",
-        \"${PUBLIC_API_URL}/auth/callback\"
-      ],
-      \"webOrigins\": [
-        \"http://127.0.0.1:13000\",
-        \"http://localhost:13000\",
-        \"${PUBLIC_API_URL}\"
-      ],
-      \"secret\": \"$KEYCLOAK_CLIENT_SECRET\"
-    }"
-  echo "✅ OIDC client updated"
+    -d "$UPDATED_CLIENT"
+
+  echo "✅ OIDC client updated (redirect URIs and web origins set, all other settings preserved)"
 fi
 
 # Add protocol mappers to OIDC client

--- a/infra/keycloak-init.sh
+++ b/infra/keycloak-init.sh
@@ -52,11 +52,25 @@ if [ "$REALM_EXISTS" = "404" ]; then
       \"enabled\": true,
       \"registrationAllowed\": false,
       \"loginWithEmailAllowed\": true,
-      \"duplicateEmailsAllowed\": false
+      \"duplicateEmailsAllowed\": false,
+      \"sslRequired\": \"none\"
     }"
   echo "✅ Realm created"
 else
-  echo "ℹ️  Realm already exists"
+  echo "ℹ️  Realm already exists, updating SSL requirement..."
+  curl -sS -X PUT \
+    "$KEYCLOAK_URL/admin/realms/$KEYCLOAK_REALM" \
+    -H "Authorization: Bearer $ADMIN_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"realm\": \"$KEYCLOAK_REALM\",
+      \"enabled\": true,
+      \"registrationAllowed\": false,
+      \"loginWithEmailAllowed\": true,
+      \"duplicateEmailsAllowed\": false,
+      \"sslRequired\": \"none\"
+    }"
+  echo "✅ Realm updated"
 fi
 
 # Create OIDC client
@@ -64,6 +78,11 @@ echo "🔐 Creating OIDC client '$KEYCLOAK_CLIENT_ID'..."
 CLIENT_EXISTS=$(curl -sS -X GET \
   "$KEYCLOAK_URL/admin/realms/$KEYCLOAK_REALM/clients?clientId=$KEYCLOAK_CLIENT_ID" \
   -H "Authorization: Bearer $ADMIN_TOKEN" | jq -r '. | length')
+
+# Get client UUID for updates
+CLIENT_UUID=$(curl -sS -X GET \
+  "$KEYCLOAK_URL/admin/realms/$KEYCLOAK_REALM/clients?clientId=$KEYCLOAK_CLIENT_ID" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" | jq -r '.[0].id // empty')
 
 if [ "$CLIENT_EXISTS" = "0" ]; then
   curl -sS -X POST \
@@ -81,20 +100,44 @@ if [ "$CLIENT_EXISTS" = "0" ]; then
       \"redirectUris\": [
         \"http://127.0.0.1:13000/auth/callback\",
         \"http://localhost:13000/auth/callback\",
-        \"http://127.0.0.1:3000/auth/callback\",
-        \"http://localhost:3000/auth/callback\"
+        \"${PUBLIC_API_URL}/auth/callback\"
       ],
       \"webOrigins\": [
         \"http://127.0.0.1:13000\",
         \"http://localhost:13000\",
-        \"http://127.0.0.1:3000\",
-        \"http://localhost:3000\"
+        \"${PUBLIC_API_URL}\"
       ],
       \"secret\": \"$KEYCLOAK_CLIENT_SECRET\"
     }"
   echo "✅ OIDC client created"
 else
-  echo "ℹ️  OIDC client already exists"
+  echo "ℹ️  OIDC client already exists, updating redirect URIs..."
+  curl -sS -X PUT \
+    "$KEYCLOAK_URL/admin/realms/$KEYCLOAK_REALM/clients/$CLIENT_UUID" \
+    -H "Authorization: Bearer $ADMIN_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"id\": \"$CLIENT_UUID\",
+      \"clientId\": \"$KEYCLOAK_CLIENT_ID\",
+      \"enabled\": true,
+      \"protocol\": \"openid-connect\",
+      \"publicClient\": false,
+      \"standardFlowEnabled\": true,
+      \"directAccessGrantsEnabled\": false,
+      \"serviceAccountsEnabled\": false,
+      \"redirectUris\": [
+        \"http://127.0.0.1:13000/auth/callback\",
+        \"http://localhost:13000/auth/callback\",
+        \"${PUBLIC_API_URL}/auth/callback\"
+      ],
+      \"webOrigins\": [
+        \"http://127.0.0.1:13000\",
+        \"http://localhost:13000\",
+        \"${PUBLIC_API_URL}\"
+      ],
+      \"secret\": \"$KEYCLOAK_CLIENT_SECRET\"
+    }"
+  echo "✅ OIDC client updated"
 fi
 
 # Add protocol mappers to OIDC client

--- a/scripts/e2e-tests.mjs
+++ b/scripts/e2e-tests.mjs
@@ -63,8 +63,8 @@ console.log(`   CI Mode: ${IS_CI}`);
 
 process.env = {
   ...process.env,
-  POSTGRES_USER: 'antithesis-test',
-  POSTGRES_DB: 'antithesis-test-db',
+  POSTGRES_USER: 'antithesis_test',
+  POSTGRES_DB: 'antithesis_test_db',
   POSTGRES_PASSWORD,
   KEYCLOAK_URL: 'http://127.0.0.1:8080',
   KEYCLOAK_ADMIN_PASSWORD,

--- a/src/controllers/dashboard.integration.test.ts
+++ b/src/controllers/dashboard.integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
 import { HTTP, controller, get } from '../lib/http/index.js';
+import { getAvailablePort } from '../lib/http/test-utils.js';
 
 // Create a test-specific dashboard controller without authentication
 // to test the rendering functionality in isolation
@@ -25,9 +26,11 @@ const testDashboardController = controller('/').endpoints([
 
 void describe('Dashboard Controller', () => {
   let server: HTTP;
-  const port = 3051; // Use a fixed test port
+  let port: number;
 
-  before(() => {
+  before(async () => {
+    port = await getAvailablePort();
+
     server = new HTTP(
       { controllers: [testDashboardController] },
       {
@@ -39,11 +42,11 @@ void describe('Dashboard Controller', () => {
       },
     );
 
-    server.start();
+    await server.start();
   });
 
-  after(() => {
-    server.stop();
+  after(async () => {
+    await server.stop();
   });
 
   void it('should return HTML with content-type text/html', async () => {

--- a/src/controllers/health.integration.test.ts
+++ b/src/controllers/health.integration.test.ts
@@ -3,12 +3,15 @@ import assert from 'node:assert';
 import { HTTP } from '../lib/http/index.js';
 import { healthController } from './health.js';
 import { health } from '../lib/health.js';
+import { getAvailablePort } from '../lib/http/test-utils.js';
 
 void describe('Health Controller', () => {
   let server: HTTP;
-  const port = 3050; // Use a fixed test port
+  let port: number;
 
-  before(() => {
+  before(async () => {
+    port = await getAvailablePort();
+
     server = new HTTP(
       { controllers: [healthController] },
       {
@@ -20,11 +23,11 @@ void describe('Health Controller', () => {
       },
     );
 
-    server.start();
+    await server.start();
   });
 
-  after(() => {
-    server.stop();
+  after(async () => {
+    await server.stop();
   });
 
   void it('should return 200 with apiResponse({healthy: true}) when all checks pass', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,8 +169,8 @@ const metaApiServer = new HTTP(
   },
 );
 
-publicApiServer.start();
-adminApiServer.start();
-metaApiServer.start();
+await publicApiServer.start();
+await adminApiServer.start();
+await metaApiServer.start();
 
 export {};

--- a/src/integration/auth.integration.test.ts
+++ b/src/integration/auth.integration.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import { PostgreSqlContainer, StartedPostgreSqlContainer } from '@testcontainers/postgresql';
 import { RedisContainer, StartedRedisContainer } from '@testcontainers/redis';
 import { getDb, closeDb } from '../lib/db/index.js';
-import { runMigrations } from '../lib/db/migrations.js';
+import { runMigrations, type MigrationDbConfig } from '../lib/db/migrations.js';
 import { Redis } from '../lib/redis.js';
 import { config } from '../lib/config.js';
 import { roleService } from '../services/role.service.js';
@@ -62,8 +62,15 @@ void describe('Auth System Integration Tests', () => {
       REDIS_PORT: redisContainer.getPort(),
     });
 
-    // Run migrations
-    await runMigrations();
+    // Run migrations with container credentials (avoids global config pollution)
+    const migrationConfig: MigrationDbConfig = {
+      host: pgContainer.getHost(),
+      port: pgContainer.getPort(),
+      database: pgContainer.getDatabase(),
+      user: pgContainer.getUsername(),
+      password: pgContainer.getPassword(),
+    };
+    await runMigrations(migrationConfig);
 
     // Initialize Redis clients
     await Redis.getClient('app');

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -70,7 +70,13 @@ const configSchema = z.object({
    * Database user (application runtime - non-superuser for RLS enforcement)
    * @example 'antithesis_app'
    */
-  DB_USER: z.string().default('antithesis_app'),
+  DB_USER: z
+    .string()
+    .regex(
+      /^[A-Za-z_][A-Za-z0-9_]*$/,
+      'DB_USER must be a valid PostgreSQL identifier (alphanumeric + underscores, cannot start with number)',
+    )
+    .default('antithesis_app'),
 
   /**
    * Database password

--- a/src/lib/http/app.integration.test.ts
+++ b/src/lib/http/app.integration.test.ts
@@ -2,16 +2,19 @@ import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
 import { HTTP } from './index.js';
 import { controller, get } from './index.js';
+import { getAvailablePort } from './test-utils.js';
 
 void describe('HTTP App - Static Assets and CSS', () => {
   let server: HTTP;
-  const port = 3054;
+  let port: number;
 
   const testController = controller('/').endpoints([
     get('/test', 'test').handler(() => Promise.resolve({ message: 'test' })),
   ]);
 
-  before(() => {
+  before(async () => {
+    port = await getAvailablePort();
+
     server = new HTTP(
       { controllers: [testController] },
       {
@@ -23,11 +26,11 @@ void describe('HTTP App - Static Assets and CSS', () => {
       },
     );
 
-    server.start();
+    await server.start();
   });
 
-  after(() => {
-    server.stop();
+  after(async () => {
+    await server.stop();
   });
 
   void it('should serve CSS from /css/main.css', async () => {

--- a/src/lib/http/app.ts
+++ b/src/lib/http/app.ts
@@ -130,14 +130,25 @@ export class HTTP {
     return this.httpServer;
   }
 
-  start() {
-    this.httpServer = this.httpServer.listen(this.httpOptions.port, () => {
-      this.logger.info(`HTTP server listening on port ${String(this.httpOptions.port)}`);
+  async start(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.httpServer.listen(this.httpOptions.port, () => {
+        this.logger.info(`HTTP server listening on port ${String(this.httpOptions.port)}`);
+        resolve();
+      });
     });
   }
 
-  stop() {
-    this.httpServer.close();
-    this.logger.info('HTTP server stopped');
+  async stop(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.httpServer.close((err) => {
+        if (err) {
+          reject(err);
+        } else {
+          this.logger.info('HTTP server stopped');
+          resolve();
+        }
+      });
+    });
   }
 }

--- a/src/lib/http/dto.integration.test.ts
+++ b/src/lib/http/dto.integration.test.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { HTTP, controller, post, apiResponse, zApiOutput } from './index.js';
 import { DTO } from '../DTO.js';
 import { metaController } from '../../controllers/meta.js';
+import { getAvailablePort } from './test-utils.js';
 
 // Test DTO schema
 const UserSchema = z.object({
@@ -39,9 +40,11 @@ const testDtoController = controller('/')
 
 void describe('DTO Integration Test', () => {
   let server: HTTP;
-  const port = 3053; // Use a unique test port
+  let port: number;
 
-  before(() => {
+  before(async () => {
+    port = await getAvailablePort();
+
     server = new HTTP(
       { controllers: [metaController, testDtoController] },
       {
@@ -53,11 +56,11 @@ void describe('DTO Integration Test', () => {
       },
     );
 
-    server.start();
+    await server.start();
   });
 
-  after(() => {
-    server.stop();
+  after(async () => {
+    await server.stop();
   });
 
   void it('should accept valid DTO data and return 200', async () => {

--- a/src/lib/http/test-utils.ts
+++ b/src/lib/http/test-utils.ts
@@ -1,0 +1,39 @@
+import { createServer } from 'node:http';
+
+/**
+ * Find an available port in the range 30000-50000
+ * Retries with a new random port if the selected port is already in use
+ *
+ * @returns A promise that resolves to an available port number
+ */
+export async function getAvailablePort(): Promise<number> {
+  const MIN_PORT = 30000;
+  const MAX_PORT = 50000;
+
+  const tryPort = async (port: number): Promise<number> => {
+    return new Promise((resolve, reject) => {
+      const server = createServer();
+
+      server.once('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EADDRINUSE') {
+          // Port in use, try another random port
+          const newPort = Math.floor(Math.random() * (MAX_PORT - MIN_PORT + 1)) + MIN_PORT;
+          resolve(tryPort(newPort));
+        } else {
+          reject(err);
+        }
+      });
+
+      server.once('listening', () => {
+        server.close(() => {
+          resolve(port);
+        });
+      });
+
+      server.listen(port);
+    });
+  };
+
+  const initialPort = Math.floor(Math.random() * (MAX_PORT - MIN_PORT + 1)) + MIN_PORT;
+  return tryPort(initialPort);
+}


### PR DESCRIPTION
## Summary

This PR enables developers to run the application with custom hostnames (e.g., remote devboxes) by making URL configuration overridable through `.env` files, while maintaining localhost defaults for standard development setups.

## Problem

Previously, the application had hardcoded `localhost` URLs in `docker-compose.yml`, which prevented OAuth authentication from working when accessing the app via a different hostname (e.g., `devbox`). This caused:
- Redirects to `localhost:8080` instead of the actual hostname
- "HTTPS required" errors from Keycloak for non-localhost connections

## Solution

### 1. Environment Variable Substitution
Updated `docker-compose.yml` to use variable substitution syntax:
```yaml
- PUBLIC_API_URL=${PUBLIC_API_URL:-http://localhost:3000}
- KEYCLOAK_PUBLIC_URL=${KEYCLOAK_PUBLIC_URL:-http://localhost:8080}
```

This allows:
- **Standard users**: Get `localhost` URLs by default
- **Custom hostname users**: Override via `.env` file (e.g., `PUBLIC_API_URL=http://devbox:3000`)

### 2. Dynamic Keycloak Configuration
Updated `infra/keycloak-init.sh` to:
- Use `$PUBLIC_API_URL` environment variable for OAuth redirect URIs and web origins
- Set Keycloak realm `sslRequired: "none"` for HTTP development access
- Support updating existing realms/clients (not just creating new ones)

### 3. No Hardcoded Hostnames
Removed all hardcoded environment-specific hostnames from shared configuration files.

## Changes Made

- `docker-compose.yml`:
  - Added variable substitution for `PUBLIC_API_URL`, `ADMIN_API_URL`, `META_API_URL`, `KEYCLOAK_PUBLIC_URL`
  - Passed `PUBLIC_API_URL` to `keycloak-init` container
  
- `infra/keycloak-init.sh`:
  - Use `${PUBLIC_API_URL}` for OAuth redirect URIs and web origins
  - Set `sslRequired: "none"` in realm configuration
  - Added realm update logic (PUT) in addition to creation
  - Added client update logic to modify existing clients

## Testing

- [x] Tested with `localhost` (default behavior)
- [x] Tested with custom hostname via `.env` override
- [x] OAuth authentication flow works correctly
- [x] Keycloak realm and client configuration applied successfully

## Impact

- **No breaking changes** for existing users (localhost remains the default)
- Enables flexible deployment configurations
- Fixes authentication issues when accessing via non-localhost hostnames

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API and Keycloak URLs configurable via environment variables with sensible defaults.
  * Test utility to allocate available ports for tests.

* **Improvements**
  * Keycloak client redirect URIs/origins use the configured public URL; setup is idempotent and relaxed for local dev.
  * Server startup/shutdown and test lifecycles are now asynchronous and awaitable.
  * Migration tooling accepts an explicit DB config object.
  * DB username validation tightened.

* **Chores**
  * E2E script POSTGRES env names normalized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->